### PR TITLE
Add a warning about 64bit examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cargo install --version "0.4.0" mdbook-tera
 Then, the book can be built using:
 
 ```
-mdboook build
+mdbook build
 cp -r static/ book/
 ```
 

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -17,6 +17,22 @@ This book is a collection of examples that demonstrate good practices to accompl
     If this is not the case, please refer to the <a href="{{ user_doc_root }}/Python-API/Installation.html">installation documentation</a> of the Python API before starting this guide.
 </p>
 {{ bulma::end_message() }}
+{{ bulma::begin_message(header="64-bit examples", class="is-warning") }}
+<p>
+  This book assumes that you are analyzing scenarios in a 64-bit context. If analyzing a scenario in a 32-bit context, then you should read from the 32-bit variants of registers or using 32-bit addresses.
+</p>
+<p>
+  So, if an example use <code>regs.rax</code>, the register should be replaced by <code>regs.eax</code>, like the following example:
+  <br/>
+  <code>
+    ctx.read(regs.rax, U64) # 64-bit
+  </code>
+  <br/>
+  <code>
+    ctx.read(regs.eax, U32) # 32-bit
+  </code>
+</p>
+{{ bulma::end_message() }}
 {{ bulma::end_bulma() }}
 
 ## Common abbreviations and variable names


### PR DESCRIPTION
Some examples works only on 64-bit scenario since they use 64-bit registers and addresses.
A warning about this is added in the indroduction page to inform the user that if he is analyzing a 32-bit scenario, he should modify some examples.