### PR TITLE
Fix minor errors in existing recipes

### DIFF
--- a/src/instruction-semantics.md
+++ b/src/instruction-semantics.md
@@ -138,7 +138,7 @@ class Disassembler:
 {{ bulma::end_bulma() }}
 
 ```py
-dsm = Disassembler
+dsm = Disassembler()
 insn = dsm.disassemble(tr)
 # Access the capstone instruction
 insn.capstone_instruction

--- a/src/listing-ossi.md
+++ b/src/listing-ossi.md
@@ -110,7 +110,7 @@ def find_first_base_address(binary: reven2.ossi.ossi.Binary):
 
 ```py
 def find_base_address_in_process(binary: reven2.ossi.ossi.Binary, process: reven2.ossi.process.Process):
-    for ctx_range in server.trace.filter(processes=(process,):
+    for ctx_range in server.trace.filter(processes=(process,)):
         for ctx in server.trace.search.binary(binary, ctx_range.begin, ctx_range.end):
             return ctx.ossi.location().base_address
 ```


### PR DESCRIPTION
- in [disassembling-reven-instructions](https://tetrane.github.io/api-cookbook/instruction-semantics.html#disassembling-reven-instructions), call the `Disassembler` constructor, fixes:

```
TypeError                                 Traceback (most recent call last)
    /tmp/ipykernel_7414/3279911869.py in <module>
          1 dsm = Disassembler
    ----> 2 insn = dsm.disassemble(tr)
          3 # Access the capstone instruction
          4 insn.capstone_instruction
    
    TypeError: disassemble() missing 1 required positional argument: 'tr'
```

- in [finding-all-the-base-addresses-of-a-binary-in-a-specified-process](https://tetrane.github.io/api-cookbook/listing-ossi.html#finding-all-the-base-addresses-of-a-binary-in-a-specified-process), add missing `)` in `find_base_address_in_process`, fixes:

```
    for ctx_range in server.trace.filter(processes=(process,):
                                                             ^
SyntaxError: invalid syntax
```