### PR TITLE
cosmetic changes to some recipes

### DIFF
--- a/src/memhist.md
+++ b/src/memhist.md
@@ -42,8 +42,8 @@ Sample output:
 {{ bulma::end_bulma() }}
 
 ```py
-for access in server.trace.memory_accesses(from_transition=trace.transition(1000),
-                                    to_transition=trace.transition(1010)):
+for access in server.trace.memory_accesses(from_transition=server.trace.transition(1000),
+                                    to_transition=server.trace.transition(1010)):
     print(access)
 ```
 

--- a/src/search-calls.md
+++ b/src/search-calls.md
@@ -14,7 +14,7 @@
 symbol_name = "CreateProcessW"
 try:
     symbol = next(server.ossi.symbols(f"^{symbol_name}$",
-                                      binary_hint=r'kernelbase\.dll'))
+                                      binary_hint=r"kernelbase\.dll"))
 except StopIteration:
     raise RuntimeError(f"Could not find symbol '{symbol_name}'")
 for ctx in server.trace.search.symbol(symbol):
@@ -67,7 +67,7 @@ def first_symbol(symbol_name):
 
 
 binary = "c:/windows/system32/ntoskrnl.exe"
-symbols = ['NtCreateFile', 'NtOpenFile', 'NtOpenDirectoryObject']
+symbols = ["NtCreateFile", "NtOpenFile", "NtOpenDirectoryObject"]
 
 symbols_name = [(first_symbol(symbol), symbol) for symbol in symbols]
 

--- a/src/search-calls.md
+++ b/src/search-calls.md
@@ -12,11 +12,12 @@
 
 ```py
 symbol_name = "CreateProcessW"
+binary_hint = r"kernelbase\.dll"
 try:
     symbol = next(server.ossi.symbols(f"^{symbol_name}$",
-                                      binary_hint=r"kernelbase\.dll"))
+                                      binary_hint=binary_hint))
 except StopIteration:
-    raise RuntimeError(f"Could not find symbol '{symbol_name}'")
+    raise RuntimeError(f"Could not find symbol '{symbol_name}' with binary hint '{binary_hint}'")
 for ctx in server.trace.search.symbol(symbol):
     print(ctx)
 ```

--- a/src/search-calls.md
+++ b/src/search-calls.md
@@ -14,7 +14,7 @@
 symbol_name = "CreateProcessW"
 try:
     symbol = next(server.ossi.symbols(f"^{symbol_name}$",
-                                      binary_hint='kernelbase\.dll'))
+                                      binary_hint=r'kernelbase\.dll'))
 except StopIteration:
     raise RuntimeError(f"Could not find symbol '{symbol_name}'")
 for ctx in server.trace.search.symbol(symbol):

--- a/src/search-values.md
+++ b/src/search-values.md
@@ -37,6 +37,9 @@ bulma::reven_version(version="v2.2.0")
 If the value you are looking for looks like a string indexed by the strings resource (defaults to strings of printable characters of length 5-128, possibly UTF-16 encoded), then you can use the strings search API, which will be the fastest way:
 
 ```py
+from_tr = server.trace.first_transition
+to_tr = server.trace.last_transition
+
 for string in server.trace.strings("Network"):
     for access in string.memory_accesses(from_tr, to_tr):
         print(access)
@@ -85,6 +88,9 @@ bulma::reven_version(version="v2.6.0")
 {{ bulma::end_bulma() }}
 
 ```py
+from_ctx = server.trace.first_context
+to_ctx = server.trace.last_context
+
 for match in server.trace.search.memory(b"\xc0\xfc\x75\x02", from_ctx, to_ctx).matches():
     print(match)
 ```


### PR DESCRIPTION
Some cosmetic changes:
- fix invalid escape sequence in binary_hint
- use double quotes for strings (except if it would require to add backslash escapes)
- add placeholder variables for binary_hint/from/to
- use `server.trace` instead of `trace` in `memory_accesses` recipe for consistency