### PR TITLE
Download mdbook binaries instead of building them from source

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,16 +18,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update && sudo apt install -y binutils build-essential
-          wget -O - https://sh.rustup.rs | sh -s -- -y -q
-          source $HOME/.cargo/env
-          cargo install --version "0.4.13" mdbook
-          cargo install --version "0.4.0" mdbook-tera
+          wget -O - https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar xvzf -
+          wget -O - https://github.com/avitex/mdbook-tera/releases/download/v0.4.2/mdbook-tera-x86_64-unknown-linux-gnu.tar.gz | tar xvzf -
 
  
       - name: Build the book
         run: |
-          MDBOOK_PREPROCESSOR__TERA__COMMAND="mdbook-tera --toml ./contexts/standalone.toml" mdbook build
+          MDBOOK_PREPROCESSOR__TERA__COMMAND="./mdbook-tera --toml ./contexts/standalone.toml" ./mdbook build
           cp -r static book/
       
       - name: Disable jekyll

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ build:
     - apt update && apt install -y --no-install-recommends ca-certificates python3 wget && wget "https://github.com/tetrane/dependencies_installer/raw/master/installer.py" && chmod +x installer.py
     - ./installer.py $(find . -wholename "*dependencies/dev")
     - source $HOME/.cargo/env
-    - MDBOOK_PREPROCESSOR__TERA__COMMAND="mdbook-tera --toml ./contexts/gitlab.toml" mdbook build
+    - MDBOOK_PREPROCESSOR__TERA__COMMAND="./mdbook-tera --toml ./contexts/gitlab.toml" ./mdbook build
     - cp -r static/ book/
   artifacts:
     paths:

--- a/dependencies/dev/common.postpkg.sh
+++ b/dependencies/dev/common.postpkg.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-# Install rust
-echo "Installing rust"
-wget -O - https://sh.rustup.rs | sh -s -- -y -q
-
-# Install rust dependencies
+# Install mdbook binaries
 echo "Installing mdbook"
-source $HOME/.cargo/env
-cargo install --version "0.4.13" mdbook
-cargo install --version "0.4.0" mdbook-tera
+wget -O - https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar xvzf -
+echo "Installing mdbook-tera"
+wget -O - https://github.com/avitex/mdbook-tera/releases/download/v0.4.2/mdbook-tera-x86_64-unknown-linux-gnu.tar.gz | tar xvzf -
+


### PR DESCRIPTION
Shortens CI duration.

Following https://github.com/avitex/mdbook-tera/issues/7#issuecomment-1002643315