### PR TITLE
Install tools in /usr/local/bin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,18 +18,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          wget -O - https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar xvzf -
-          wget -O - https://github.com/avitex/mdbook-tera/releases/download/v0.4.2/mdbook-tera-x86_64-unknown-linux-gnu.tar.gz | tar xvzf -
+          wget -O - https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf - -C /usr/local/bin
+          wget -O - https://github.com/avitex/mdbook-tera/releases/download/v0.4.2/mdbook-tera-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf - -C /usr/local/bin
 
- 
+
       - name: Build the book
         run: |
-          MDBOOK_PREPROCESSOR__TERA__COMMAND="./mdbook-tera --toml ./contexts/standalone.toml" ./mdbook build
+          MDBOOK_PREPROCESSOR__TERA__COMMAND="mdbook-tera --toml ./contexts/standalone.toml" mdbook build
           cp -r static book/
-      
+
       - name: Disable jekyll
         run: touch book/.nojekyll
-        
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.ref == 'refs/heads/master' }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,8 +9,7 @@ build:
   script:
     - apt update && apt install -y --no-install-recommends ca-certificates python3 wget && wget "https://github.com/tetrane/dependencies_installer/raw/master/installer.py" && chmod +x installer.py
     - ./installer.py $(find . -wholename "*dependencies/dev")
-    - source $HOME/.cargo/env
-    - MDBOOK_PREPROCESSOR__TERA__COMMAND="./mdbook-tera --toml ./contexts/gitlab.toml" ./mdbook build
+    - MDBOOK_PREPROCESSOR__TERA__COMMAND="mdbook-tera --toml ./contexts/gitlab.toml" mdbook build
     - cp -r static/ book/
   artifacts:
     paths:

--- a/dependencies/dev/common.postpkg.sh
+++ b/dependencies/dev/common.postpkg.sh
@@ -2,7 +2,6 @@
 
 # Install mdbook binaries
 echo "Installing mdbook"
-wget -O - https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar xvzf -
+wget -O - https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf - -C /usr/local/bin
 echo "Installing mdbook-tera"
-wget -O - https://github.com/avitex/mdbook-tera/releases/download/v0.4.2/mdbook-tera-x86_64-unknown-linux-gnu.tar.gz | tar xvzf -
-
+wget -O - https://github.com/avitex/mdbook-tera/releases/download/v0.4.2/mdbook-tera-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf - -C /usr/local/bin


### PR DESCRIPTION
This MR makes the GH actions avoid putting the tools in the middle of the source tree, but instead put them in a system path.